### PR TITLE
Various fixes and improvements

### DIFF
--- a/lib/docbookrx.rb
+++ b/lib/docbookrx.rb
@@ -6,6 +6,9 @@ module Docbookrx
     xmldoc = ::Nokogiri::XML::Document.parse str
     raise 'Not a parseable document' unless (root = xmldoc.root)
     visitor = DocbookVisitor.new opts
+    if xmldoc.internal_subset
+      visitor.convert_entities xmldoc.internal_subset.children
+    end
     root.accept visitor
     visitor.lines * "\n"
   end

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -79,7 +79,6 @@ class DocbookVisitor
     @normalize_ids = opts.fetch :normalize_ids, true
     @compat_mode = opts[:compat_mode]
     @attributes = opts[:attributes] || {}
-    @runin_admonition_label = opts.fetch :runin_admonition_label, true
     @sentence_per_line = opts.fetch :sentence_per_line, true
     @preserve_line_wrap = if @sentence_per_line
       false
@@ -525,21 +524,12 @@ class DocbookVisitor
     elements = node.elements
     append_blank_line
     append_block_title node
-    if elements.size == 1 && (PARA_TAG_NAMES.include? (child = elements.first).name)
-      if @runin_admonition_label
-        append_line %(#{label}: #{format_text child})
-      else
-        append_line %([#{label}])
-        append_line (format_text child)
-      end
-    else
-      append_line %([#{label}])
-      append_line '===='
-      @adjoin_next = true
-      proceed node
-      @adjoin_next = false
-      append_line '===='
-    end
+    append_line %([#{label}])
+    append_line '===='
+    @adjoin_next = true
+    proceed node
+    @adjoin_next = false
+    append_line '===='
     false
   end
 

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -868,21 +868,17 @@ class DocbookVisitor
       (head.css '> row > entry').each do |cell|
         append_line %(| #{text cell})
       end
+      append_blank_line
     end
     (node.css '> tgroup > tbody > row').each do |row|
       append_blank_line
       row.elements.each do |cell|
-        next if !(element = cell.elements.first)
-        if element.text.empty?
-          append_line '|'
+        case cell.name
+        when 'literallayout'
+          append_line %(|`#{text cell}`)
         else
-          append_line %(| #{text cell})
-          #case element.name
-          #when 'literallayout'
-          #  append_line %(|`#{text cell}`)
-          #else
-          #  append_line %(|#{text cell})
-          #end
+          append_line '|'
+          proceed cell
         end
       end
     end

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -51,7 +51,7 @@ class DocbookVisitor
 
   SECTION_NAMES = DOCUMENT_NAMES + ['chapter', 'part'] + NORMAL_SECTION_NAMES + SPECIAL_SECTION_NAMES
 
-  ANONYMOUS_LITERAL_NAMES = ['code', 'command', 'computeroutput', 'database', 'function', 'literal', 'tag', 'userinput']
+  ANONYMOUS_LITERAL_NAMES = ['abbrev', 'acronym', 'code', 'command', 'computeroutput', 'database', 'function', 'literal', 'tag', 'userinput']
 
   NAMED_LITERAL_NAMES = ['application', 'classname', 'constant', 'envar', 'exceptionname', 'interfacename', 'methodname', 'option', 'parameter', 'property', 'replaceable', 'type', 'varname']
 

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -278,9 +278,10 @@ class DocbookVisitor
     false
   end
 
-  # pass thru XML entities unchanged, eg., for &rarr;
   def visit_entity_ref node
-    append_text %(#{node})
+    append_text %({#{node.name}})
+    #workaround for missing space, nokogiri bug?
+    append_text ' ' if((next_node = node.next) && next_node.text.match(/^\s/))
     false
   end
 
@@ -1306,6 +1307,22 @@ class DocbookVisitor
 
   def unwrap_text text
     text.gsub WrappedIndentRx, ''
+  end
+
+  def convert_entities entities
+    entities.each do |entity|
+      next if entity.comment?
+      append_line ":#{entity.name}: pass:q["
+      if entity.system_id
+        append_text "include::#{entity.system_id}.adoc[]"
+      else
+        entity.children.each do |gchild|
+          gchild.accept self
+        end
+      end
+      append_text ']'
+    end
+    append_blank_line  if !entities.empty?
   end
 end
 end

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -910,8 +910,11 @@ class DocbookVisitor
         if is_first
           text = text.lstrip
         elsif leading_space_match && !!(text !~ LeadingSpaceRx)
-          # QUESTION if leading space was an endline, should we restore the endline or just put a space char?
-          text = %(#{leading_space_match[0]}#{text})
+          if @lines[-1] == "----" || @lines[-1] == "===="
+            text = %(#{leading_space_match[0]}#{text})
+          else
+            text = %( #{text})
+          end
         end
 
         # FIXME sentence-per-line logic should be applied at paragraph block level only

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -1002,7 +1002,13 @@ class DocbookVisitor
 
   def visit_emphasis node
     quote_char = node.attr('role') == 'strong' ? '*' : '_'
-    append_text %(#{quote_char}#{format_text node}#{quote_char})
+    times = 1
+    if((prev_node = node.previous) && prev_node.type == TEXT_NODE && /\p{Word}\Z/ =~ prev_node.text) ||
+      ((next_node = node.next) && next_node.type == TEXT_NODE && /\A\p{Word}/ =~ next_node.text)
+      times = 2
+    end
+
+    append_text %(#{quote_char * times}#{format_text node}#{quote_char * times})
     false
   end
 

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -946,7 +946,12 @@ class DocbookVisitor
     url = if node.name == 'ulink'
       node.attr 'url'
     else
-      (node.attribute_with_ns 'href', XlinkNs).value
+      href = (node.attribute_with_ns 'href', XlinkNs)
+      if (href)
+        href.value
+      else
+        node.text
+      end
     end
     prefix = 'link:'
     if url.start_with?('http://') || url.start_with?('https://')

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -434,8 +434,12 @@ class DocbookVisitor
       end
       format_text title_node
     else
-      warn %(No title found for section node: #{node})
-      'Unknown Title!'
+      if special
+        special.capitalize
+      else
+        warn %(No title found for section node: #{node})
+        'Unknown Title!'
+      end
     end
     if (id = (resolve_id node, normalize: @normalize_ids)) && id != (generate_id title)
       append_line %([[#{id}]])

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -679,8 +679,16 @@ class DocbookVisitor
 
   def visit_bibliomixed node
     append_blank_line
-    proceed node
-    append_line @lines.pop.sub(/^\[(.*?)\]/, '* [[[\\1]]]')
+    append_text '- '
+    node.children.each do |child|
+      if child.name == 'abbrev'
+        append_text %([[[#{child.text}]]] )
+      elsif child.name == 'title'
+        append_text child.text
+      else
+        child.accept self
+      end
+    end
     false
   end
 

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -320,4 +320,37 @@ Apple, oranges and bananas
 
     expect(output).to include(expected)
   end
+
+  it 'should convert quandaset elements to Q and A list' do
+    input = <<-EOS
+<article xmlns='http://docbook.org/ns/docbook'>
+<qandaset>
+<qandadiv>
+<title>Various Questions</title>
+<qandaentry xml:id="some-question">
+<question>
+<para>My question?</para>
+</question>
+<answer>
+<para>My answer!</para>
+</answer>
+</qandaentry>
+</qandadiv>
+</qandaset>
+</article>
+    EOS
+
+    expected = <<-EOS.rstrip
+.Various Questions
+
+[[_some_question]]
+My question?::
+
+My answer!
+    EOS
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
 end

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -353,4 +353,14 @@ My answer!
 
     expect(output).to include(expected)
   end
+
+  it 'should convert emphasis elements to emphasized text' do
+    input = "<para><emphasis>Apple</emphasis> or <emphasis>pine</emphasis>apple.</para>"
+
+    expected = "_Apple_ or __pine__apple"
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
 end

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -310,4 +310,14 @@ Apple, oranges and bananas
 
     expect(output).to include(expected)
   end
+
+  it 'should accept special section names without title' do
+    input = '<bibliography></bibliography>'
+
+    expected = '= Bibliography'
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
 end

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -285,4 +285,29 @@ void qsort (void *dataptr[],
 
     expect(output).to include(expected)
   end
+
+  it 'should convert note element to NOTE' do
+    input = <<-EOS
+<note>
+  <para>
+    Please note the fruit:
+    <screen>Apple, oranges and bananas</screen>
+  </para>
+</note>
+    EOS
+
+    expected = <<-EOS.rstrip
+[NOTE]
+====
+Please note the fruit: 
+----
+Apple, oranges and bananas
+----  
+====
+    EOS
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
 end

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe 'Conversion' do
@@ -358,6 +359,37 @@ My answer!
     input = "<para><emphasis>Apple</emphasis> or <emphasis>pine</emphasis>apple.</para>"
 
     expected = "_Apple_ or __pine__apple"
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
+
+  it 'should convert bibliography section to bibliography section' do
+    input = <<-EOS
+<article xmlns='http://docbook.org/ns/docbook'
+         xmlns:xl="http://www.w3.org/1999/xlink"
+         version="5.0" xml:lang="en">
+
+<bibliography xml:id="references">
+<bibliomixed>
+<abbrev>RNCTUT</abbrev>
+Clark, James – Cowan, John – MURATA, Makoto: <title>RELAX NG Compact Syntax Tutorial</title>.
+Working Draft, 26 March 2003. OASIS. <bibliomisc><link xl:href="http://relaxng.org/compact-tutorial-20030326.html"/></bibliomisc>
+</bibliomixed>
+</bibliography>
+
+</article>
+    EOS
+
+    expected = <<-EOS.rstrip
+[bibliography]
+[[_references]]
+== Bibliography
+- [[[RNCTUT]]] 
+Clark, James – Cowan, John – MURATA, Makoto: RELAX NG Compact Syntax Tutorial.
+Working Draft, 26 March 2003. OASIS. http://relaxng.org/compact-tutorial-20030326.html
+    EOS
 
     output = Docbookrx.convert input
 

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -77,10 +77,15 @@ content
 
   it 'should convert uri element to uri macro' do
     input = <<-EOS
+<article xmlns='http://docbook.org/ns/docbook'>
 <para xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">Read about <uri xlink:href="http://en.wikipedia.org/wiki/Object-relational_mapping">Object-relational mapping</uri> on Wikipedia.</para>
+<para>All DocBook V5.0 elements are in the namespace <uri>http://docbook.org/ns/docbook</uri>.</para>
+</article>
     EOS
 
-    expected = 'Read about http://en.wikipedia.org/wiki/Object-relational_mapping[Object-relational mapping] on Wikipedia.'
+    expected = 'Read about http://en.wikipedia.org/wiki/Object-relational_mapping[Object-relational mapping] on Wikipedia.
+
+All DocBook V5.0 elements are in the namespace http://docbook.org/ns/docbook.'
 
     output = Docbookrx.convert input
 


### PR DESCRIPTION
Hi,

I got bored and decided to try to convert the Docbook V5.0 Howto found here:

http://www.docbook.org/docs/howto/

into asciidoc.  I found quite a few problems, as you can see from the number of changes.  It works pretty well now after all the changes (not quite sure which version I used).  A couple of things surprise me:

```
Co-occurrencesfootnote:[RELAX NG gram...]
```

This seems to work fine without a space in front of footnote....

```
I'm using Altova XMLSpy to validate DocBook V5.0 instances against the W3C XML S
chema ([path]_docbook.xsd_). XMLSpy complains about undefined `xml:id` attribute
s?::
```

This seem to be converted correctly by asciidoctor-pdf, but not asciidoctor output looks strange.  Do you see the same problem?
