### PR TITLE
Fixing possible nil in proces_table

### DIFF
--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -839,7 +839,7 @@ class DocbookVisitor
     row1 = body.at_css '> row'
     row1_cells = row1.elements
     numcols.times do |i|
-      next if !(element = row1_cells[i].elements.first)
+      next if (row1_cells[i].nil? || !(element = row1_cells[i].elements.first))
       case element.name
       when 'literallayout'
         cols[i] = %(#{cols[i]}*l)


### PR DESCRIPTION
I ran into the following exception: this PR fixes that. 
````
/home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:846:in `block in process_table': undefined method `name' for nil:NilClass (NoMethodError)
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:844:in `times'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:844:in `process_table'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:828:in `visit_table'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:127:in `visit'
	from /home/mrietvel/.gem/ruby/2.3.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node.rb:595:in `accept'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:138:in `block in traverse_children'
	from /home/mrietvel/.gem/ruby/2.3.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:187:in `block in each'
	from /home/mrietvel/.gem/ruby/2.3.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:186:in `upto'
	from /home/mrietvel/.gem/ruby/2.3.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node_set.rb:186:in `each'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:137:in `traverse_children'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:462:in `process_section'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx/docbook_visitor.rb:127:in `visit'
	from /home/mrietvel/.gem/ruby/2.3.0/gems/nokogiri-1.6.7.2/lib/nokogiri/xml/node.rb:595:in `accept'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx.rb:12:in `convert'
	from /home/mrietvel/Workspace/references/docbookrx/lib/docbookrx.rb:24:in `convert_file'
	from /home/mrietvel/Workspace/references/docbookrx/bin/docbookrx:32:in `<main>'
````