### PR TITLE
Avoid modified .bundle/config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_BUILD__NOKOGIRI: "--use-system-libraries"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /pkg/
 /samples/
 /tmp/
+/.bundle

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+ENV['NOKOGIRI_USE_SYSTEM_LIBRARIES'] = "1"
 Dir.glob('tasks/*.rake').each { |file| load file }
 
 task default: %w(spec)


### PR DESCRIPTION
I think we should not need .bundle/config file to git repository.
Because it is modified file, depending on user's environment.
And its situation is not good for the development.
For example, it prevents user to do "git rebase".

**Before modification**
```
$bundle install --path vendor/bundle

$ git status
...
  modified:   .bundle/config 
...
```

I can understand why you added the file, because of compiling nokogiri with system library.
And we can set a environment variable to get same result.

**After modification**
```
$ bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Resolving dependencies...
Installing rake 10.4.2
Installing diff-lcs 1.2.5
Installing mini_portile2 2.0.0
Installing rspec-support 3.4.1
Using bundler 1.12.4
Installing nokogiri 1.6.7.2 with native extensions <--Check this.
Installing rspec-core 3.4.4
Installing rspec-expectations 3.4.0
Installing rspec-mocks 3.4.1
Using docbookrx 1.0.0 from source at `.`
Installing rspec 3.4.0
Bundle complete! 3 Gemfile dependencies, 11 gems now installed.
Bundled gems are installed into ./vendor/bundle.

$ git status
On branch feature/modified-bundle-config
Your branch is up-to-date with 'origin/feature/modified-bundle-config'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	vendor/

nothing added to commit but untracked files present (use "git add" to track)
```
