### PR TITLE
Fix for warning messages.

### DIFF
--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -340,7 +340,7 @@ class DocbookVisitor
 
   ## Node visitor callbacks
 
- def default_visit node
+  def default_visit node
     warn %(No visitor defined for <#{node.name}>! Skipping.)
     false
   end
@@ -598,7 +598,6 @@ class DocbookVisitor
   def process_admonition node
     name = node.name
     label = name.upcase
-    elements = node.elements
     append_blank_line unless @continuation
     append_block_title node
     append_line %([#{label}])
@@ -631,7 +630,7 @@ class DocbookVisitor
     visit_orderedlist node
   end
 
- def visit_orderedlist node
+  def visit_orderedlist node
     append_blank_line
     # TODO no title?
     if (numeration = (node.attr 'numeration')) && numeration != 'arabic'
@@ -994,8 +993,9 @@ class DocbookVisitor
     numcols = (node.at_css '> tgroup').attr('cols').to_i
     unless (row_node = (node.at_css '> tgroup > thead > row')).nil?
       if (numheaders = row_node.elements.length) != numcols
-        title = " \'" + ((title_node = (node.at_css '> title')).nil? ? "" : title_node.children[0].text) 
-                + "\'"
+        title = " \'" +
+          ((title_node = (node.at_css '> title')).nil? ?
+          "" : title_node.children[0].text) + "\'"
         warn %(#{numcols} columns specified in table#{title}, but only #{numheaders} headers)
       end
     end
@@ -1289,10 +1289,10 @@ class DocbookVisitor
     case name
     # ex. <menuchoice><guimenu>System</guimenu><guisubmenu>Documentation</guisubmenu></menuchoice>
     when 'menuchoice'
-      items = node.children.map {|node|
-        if (node.type == ELEMENT_NODE) && ['guimenu', 'guisubmenu', 'guimenuitem'].include?(node.name)
-          node.instance_variable_set :@skip, true
-          node.text
+      items = node.children.map {|n|
+        if (n.type == ELEMENT_NODE) && ['guimenu', 'guisubmenu', 'guimenuitem'].include?(n.name)
+          n.instance_variable_set :@skip, true
+          n.text
         end
       }.compact
       append_text %(menu:#{items[0]}[#{items[1..-1] * ' > '}])
@@ -1450,7 +1450,7 @@ class DocbookVisitor
           append_text ','
           append_line ' ' * indent
         end
-        append_text paramdef.text.sub /\n.*/m, ''
+        append_text paramdef.text.sub(/\n.*/m, '')
         if (param = paramdef.at_xpath 'db:funcparams', 'db': DocbookNs)
           append_text %[ (#{param.text})]
         end


### PR DESCRIPTION
I fixed for warning messages.

Because if we keep such kind of warning messages, it makes us hard to find new warnings, and it leads up new warnings

It is "Broken windows theory"
https://en.wikipedia.org/wiki/Broken_windows_theory

About the fix of L988, I followed popular style, max line length:  80 byte that is used for rubocop.

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
```

**Before modification**
```
$ ruby -cW lib/docbookrx/docbook_visitor.rb
lib/docbookrx/docbook_visitor.rb:346: warning: mismatched indentations at 'end' with 'def' at 343
lib/docbookrx/docbook_visitor.rb:601: warning: assigned but unused variable - elements
lib/docbookrx/docbook_visitor.rb:642: warning: mismatched indentations at 'end' with 'def' at 634
lib/docbookrx/docbook_visitor.rb:998: warning: possibly useless use of +@ in void context
lib/docbookrx/docbook_visitor.rb:1292: warning: shadowing outer local variable - node
lib/docbookrx/docbook_visitor.rb:1453: warning: ambiguous first argument; put parentheses or a space even after `/' operator
Syntax OK
```

**After modification**
```
$ ruby -cW lib/docbookrx/docbook_visitor.rb
Syntax OK
```
