### PR TITLE
Add feature to convert from condition to ifdef for #43

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -101,6 +101,28 @@ The script will automatically create the output file [path]_sample.adoc_, replac
 The converter is not perfect yet, but we'll get there with your help.
 You'll can find a list of tasks that need attention listed in the WORKLOG.adoc file.
 
+=== Conditional attribute
+
+The DocBook conditional attribute "condition" is replaced to "ifdef" macro.
+
+Take note the marco is on a line by itself.
+
+For example, in the case of there is the DocBook inline element with condition.
+
+ a<phrase condition="foo">b</phrase>c
+
+It is converted to below AsciiDoc format.
+
+ a
+ ifdef::foo[]
+ b
+ endif::foo[]
+ c
+
+When it is converted to html format, the output is displayed with both a space before "b" and a space after "b".
+
+ a b c
+
 == About this Project
 
 === Authors

--- a/lib/docbookrx.rb
+++ b/lib/docbookrx.rb
@@ -7,6 +7,7 @@ module Docbookrx
     raise 'Not a parseable document' unless (root = xmldoc.root)
     visitor = DocbookVisitor.new opts
     root.accept visitor
+    visitor.after
     visitor.lines * "\n"
   end
 


### PR DESCRIPTION
I added new feature about condition.
https://github.com/asciidoctor/docbookrx/issues/43

The "condition" of DocBook XSL is converted to "ifdef".

There are several restriction for usage.
- The condition is not supported for several XML nodes, and cases. For example.
  - The node itself is not supported for DocBookRX itself that warns "No visitor defined for <#{node.name}>! Skipping.", it does not work.
  - subtitle node in section, productname, 
  - xi:include (include tag looks supported, but xi:include looks not supported.)

Could you check my code?
Thanks.
