### PR TITLE
Fixes for conversion of procedure element

### DIFF
--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -331,7 +331,7 @@ class DocbookVisitor
     else
       method_name = method.to_s
       case method_name
-      when "visit_itemizedlist", "visit_orderedlist"
+      when "visit_itemizedlist", "visit_orderedlist", "visit_procedure", "visit_substeps", "visit_stepalternatives"
         @list_depth -= 1
       when "visit_table", "visit_informaltable"
         @in_table = false
@@ -717,7 +717,7 @@ class DocbookVisitor
           end
 
           local_continuation = false
-          unless i == 0 || first_line || (child.name == 'literallayout' || child.name == 'itemizedlist' || child.name == 'orderedlist')
+          unless i == 0 || first_line || (child.name == 'literallayout' || child.name == 'itemizedlist' || child.name == 'orderedlist' || child.name == 'procedure')
             append_line '+'
             @continuation = true
             local_continuation = true
@@ -757,7 +757,7 @@ class DocbookVisitor
               if first_line && ! local_continuation
                 append_text ' {empty}' # necessary to fool asciidoctorj into thinking that this is a listitem
               end
-              unless local_continuation || (child.name == 'literallayout' || child.name == 'itemizedlist' || child.name == 'orderedlist')
+              unless local_continuation || (child.name == 'literallayout' || child.name == 'itemizedlist' || child.name == 'orderedlist' || child.name == 'procedure')
                 append_line '+'
               end
               @continuation = false

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -672,6 +672,76 @@ break!
     expect(output).to include(expected)
   end
 
+  it 'should convert itemizedlist nested inside procedure, and procedure nested inside itemizedlist correctly' do
+    input = <<-EOS
+<article xmlns='http://docbook.org/ns/docbook'
+         xmlns:xl="http://www.w3.org/1999/xlink"
+         version="5.0" xml:lang="en">
+  <itemizedlist>
+    <listitem>
+      <para>simple</para>
+    </listitem>
+    <listitem>
+      <para>procedure inside listitem</para>
+      <procedure>
+        <step>
+          <para>first step</para>
+        </step>
+        <step>
+          <para>second step</para>
+        </step>
+      </procedure>
+    </listitem>
+  </itemizedlist>
+  <para>break!</para>
+  <procedure>
+    <step>
+      <para>first step</para>
+    </step>
+    <step>
+      <para>second step</para>
+    </step>
+    <step>
+      <para>third step is a nested itemizedlist</para>
+      <itemizedlist>
+        <listitem>
+          <para>foo</para>
+        </listitem>
+        <listitem>
+          <para>bar</para>
+        </listitem>
+      </itemizedlist>
+    </step>
+    <step>
+      <para>fourth step</para>
+    </step>
+  </procedure>
+</article>
+    EOS
+
+    expected = <<-EOS
+
+* simple
+* procedure inside listitem
+
+.. first step
+.. second step
+
+break!
+
+
+. first step
+. second step
+. third step is a nested itemizedlist
+** foo
+** bar
+. fourth step
+    EOS
+    output = Docbookrx.convert input
+
+    expect(output).to eql(expected)
+  end
+
   it 'should add all table lines and escape | characters in table text' do
     input = <<-EOS
 <article xmlns='http://docbook.org/ns/docbook'


### PR DESCRIPTION
Fixes a couple of issues around conversion of DocBook procedures. In particular, the code was failing to decrement the `list_depth` at the end of a `procedure`, which was messing up the indentation of all subsequent lists. Also, the logic of `@continuation` in the `visit_listitem` method needed to take account of procedures properly. Finally, I added an rspec test to validate these fixes for `procedure`.