### PR TITLE
Fixed generation of document header for DocBook 5 book

### DIFF
--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -418,6 +418,11 @@ class DocbookVisitor
   end
 
   def process_doc node
+    # In DocBook 5.0, title is directly inside book/article element
+    if (title = text_at_css node, '> title')
+      append_line %(= #{title})
+      append_blank_line
+    end
     @level += 1
     proceed node, :using_elements => true
     @level -= 1
@@ -425,8 +430,11 @@ class DocbookVisitor
   end
 
   def process_info node
-    title = text_at_css node, '> title'
-    append_line %(= #{title})
+    # In DocBook 4.5, title is nested inside info element
+    if (title = text_at_css node, '> title')
+      append_line %(= #{title})
+      append_blank_line
+    end
     authors = []
     (node.css 'author').each do |author_node|
       # FIXME need to detect DocBook 4.5 vs 5.0 to handle names properly

--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -439,7 +439,7 @@ class DocbookVisitor
     (node.css 'author').each do |author_node|
       # FIXME need to detect DocBook 4.5 vs 5.0 to handle names properly
       author = if (personname_node = (author_node.at_css 'personname'))
-        text personname_node
+        [(text_at_css personname_node, 'firstname'), (text_at_css personname_node, 'surname')].compact * ' '
       else
         [(text_at_css author_node, 'firstname'), (text_at_css author_node, 'surname')].compact * ' '
       end

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 describe 'Conversion' do
-  it 'should create a document header with title, author and attributes' do
+  it 'should create a document header with title, author and attributes from DocBook 4.5 content' do
     input = <<-EOS
 <?xml version="1.0" encoding="UTF-8"?>
 <book xmlns="http://docbook.org/ns/docbook">
@@ -23,6 +23,48 @@ describe 'Conversion' do
 
     expected = <<-EOS.rstrip
 = Document Title
+
+Doc Writer <doc@example.com>
+:doctype: book
+:sectnums:
+:toc: left
+:icons: font
+:experimental:
+
+== First Section
+
+content
+EOS
+
+    output = Docbookrx.convert input
+
+    expect(output).to eq(expected)
+  end
+
+  it 'should create a document header with title, author and attributes from DocBook 5 content' do
+    input = <<-EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<book xmlns="http://docbook.org/ns/docbook">
+<title>Document Title</title>
+<info>
+<author>
+<personname>
+<firstname>Doc</firstname>
+<surname>Writer</surname>
+</personname>
+<email>doc@example.com</email>
+</author>
+</info>
+<section>
+<title>First Section</title>
+<para>content</para>
+</section>
+</book>
+    EOS
+
+    expected = <<-EOS.rstrip
+= Document Title
+
 Doc Writer <doc@example.com>
 :doctype: book
 :sectnums:


### PR DESCRIPTION
In DocBook 5, the title must appear directly under the book element (nested as `book > title`), in contrast to the DocBook 4.5 convention, where the book title is inside the info element (nested as `book > info > title`). In DocBook 5, the author's firstname and surname must also be wrapped inside the `personname` element. A spec test was added for the DocBook 5 format book header.