### PR TITLE
Convert figure element's xml:id attribute into ID anchor to enable linking to figures

### DIFF
--- a/lib/docbookrx/docbook_visitor.rb
+++ b/lib/docbookrx/docbook_visitor.rb
@@ -1485,6 +1485,9 @@ class DocbookVisitor
   # FIXME share logic w/ visit_inlinemediaobject, which is the same here except no block_title and uses append_text, not append_line
   def visit_figure node
     append_blank_line
+    if (id = (resolve_id node, normalize: @normalize_ids))
+      append_line %([[#{id}]])
+    end
     append_block_title node
     if (image_node = node.at_css('imageobject imagedata'))
       src = image_node.attr('fileref')

--- a/spec/lib/docbookrx/docbookrx_spec.rb
+++ b/spec/lib/docbookrx/docbookrx_spec.rb
@@ -1037,7 +1037,39 @@ image::images/dummy.png[some screenshot]
     EOS
     output = Docbookrx.convert input
     expect(output).to eq(expected)
-end
+  end
+
+  it 'adds an XML ID for figures' do
+
+    input = <<-EOS
+<article xmlns='http://docbook.org/ns/docbook'
+         xmlns:xl="http://www.w3.org/1999/xlink"
+         version="5.0" xml:lang="en">
+  <para>See <xref linkend="sample-figure"/>
+  <figure xml:id="sample-figure">
+    <title>Local History</title>
+    <mediaobject>
+      <imageobject>
+        <imagedata fileref="images/dummy.png"/>
+      </imageobject>
+    </mediaobject>
+  </figure>
+
+</article>
+    EOS
+
+    expected = <<-EOS.rstrip
+See <<_sample_figure>>
+
+[[_sample_figure]]
+.Local History
+image::images/dummy.png[]
+    EOS
+
+    output = Docbookrx.convert input
+
+    expect(output).to include(expected)
+  end
 
   it 'should correctly convert varlistentry elements with nested lists' do
     input = <<-EOS


### PR DESCRIPTION
Previously, links to figures were broken, because no ID anchor was being generated for figures. This fix extracts the value of the `xml:id` attribute from the `figure` element and uses it to generate an anchor, `[[XmlId]]`.