### PR TITLE
fix "cannot load such file -- docbookrx (LoadError)"

### DIFF
--- a/docbookrx.gemspec
+++ b/docbookrx.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |s|
   #s.required_ruby_version = '>= 2.3.0'
 
   files = begin
-    IO.popen('git ls-files -z') {|io| io.read }.split "\0"
+    git_files = IO.popen('git ls-files -z') {|io| io.read }.split "\0"
+    fail $?.exitstatus unless $?.success?
+    git_files
   rescue
     Dir['**/*']
   end


### PR DESCRIPTION
Make sure all files required are installed via gem
even if git executable is present.

IO.popen() will not raise an exception if the command
runs and fails with an error message.
An extra check is needed for the exit code.

Inspired by: https://stackoverflow.com/a/30940226
Downstream: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=272554